### PR TITLE
Add parent env functionality

### DIFF
--- a/DBEnvironmentConfiguration.podspec
+++ b/DBEnvironmentConfiguration.podspec
@@ -5,10 +5,10 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 Super-simple environment configuration for iOS apps. Switch between environments by changing one word.
                        DESC
-  s.homepage         = "https://github.com/DavidBenko/DBEnvironmentConfiguration"
+  s.homepage         = "https://github.com/armintelker/DBEnvironmentConfiguration"
   s.license          = 'MIT'
   s.author           = { "David Benko" => "dbenko@prndl.us" }
-  s.source           = { :git => "https://github.com/DavidBenko/DBEnvironmentConfiguration.git", :tag => s.version.to_s }
+  s.source           = { :git => "https://github.com/armintelker/DBEnvironmentConfiguration.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/davidwbenko'
 
   s.platform     = :ios

--- a/DBEnvironmentConfiguration/DBEnvironmentConfiguration.h
+++ b/DBEnvironmentConfiguration/DBEnvironmentConfiguration.h
@@ -37,6 +37,14 @@ typedef enum DBBuildType{
 + (void)setEnvironment:(NSString *)environment;
 
 /**
+ * Sets environment to read values with parentEenvironment.
+ *
+ * @param environment The name of the environment as it appears in the file
+ * @param environment The name of the parent environment as it appears in the file
+ *
+ */
++ (void)setEnvironment:(NSString *)environment parentEnvironment:(NSString *)parentEnvironment;
+/**
  * Sets file to read values from.
  * Defaults to environments.json
  *

--- a/DBEnvironmentConfiguration/DBEnvironmentConfiguration.m
+++ b/DBEnvironmentConfiguration/DBEnvironmentConfiguration.m
@@ -13,9 +13,11 @@
 @interface DBEnvironmentConfiguration (){
     bool _shouldAutodetect;
     NSString *_currentEnvironment;
+    NSString *_parentEnvironment;
     NSString *_resource;
     NSString *_resourceExtension;
     NSDictionary *_configuration;
+    NSDictionary *_parentConfig;
     NSDictionary *_environmentMapping;
     DBBuildType _detectedBuildType;
 }
@@ -191,8 +193,29 @@ NSDictionary* getConfigurationFromFile(NSString *resource, NSString *type, NSStr
     sharedInstance->_shouldAutodetect = false;
 }
 
+
++ (void)setEnvironment:(NSString *)environment parentEnvironment:(NSString *)parentEnvironment {
+    if (![environment isEqualToString:sharedInstance->_currentEnvironment]) {
+        sharedInstance->_currentEnvironment = environment;
+        sharedInstance->_parentEnvironment = parentEnvironment;
+        sharedInstance->_configuration = getConfigurationFromFile(sharedInstance->_resource, sharedInstance->_resourceExtension, sharedInstance->_currentEnvironment);
+        sharedInstance->_parentConfig = getConfigurationFromFile(sharedInstance->_resource, sharedInstance->_resourceExtension, sharedInstance->_parentEnvironment);
+    }
+    sharedInstance->_shouldAutodetect = false;
+}
+
 #pragma mark - Values
 + (NSString *)valueForKey:(NSString *)key{
-    return [sharedInstance->_configuration objectForKey:key];
+    id object = (sharedInstance->_configuration)[key];
+    if (object) {
+        return object;
+    }
+    id parentObject = (sharedInstance->_parentConfig)[key];
+    
+    if (parentObject) {
+        return parentObject;
+    }
+    
+    return nil;
 }
 @end


### PR DESCRIPTION
I have add the possibility to specify a parent environment.

``` json
{
    "Base": {
        "AppID": "123",
        "Host": "https://foo.bar"
    },
    "Production": {
        "Host": "https://more.foo.bar",
        "Logging": 0
    },
    "Sandbox": {
        "Logging": 1
    }
}

```

``` objc

[DBEnvironmentConfiguration setEnvironment:@"Production" parentEnvironment:@"Base"];
[DBEnvironmentConfiguration valueForKey:@"AppID"]; // @"123"
[DBEnvironmentConfiguration valueForKey:@"Host"]; // @"https://more.foo.bar"
[DBEnvironmentConfiguration valueForKey:@"Logging"]; // 0
```

``` objc
[DBEnvironmentConfiguration setEnvironment:@"Sandbox" parentEnvironment:@"Base"];
[DBEnvironmentConfiguration valueForKey:@"AppID"]; // @"123"
[DBEnvironmentConfiguration valueForKey:@"Host"]; // @"https://foo.bar"
[DBEnvironmentConfiguration valueForKey:@"Logging"]; // 1
```
